### PR TITLE
Fix to Support Grammarly Extension

### DIFF
--- a/quillEditor.component.ts
+++ b/quillEditor.component.ts
@@ -108,11 +108,13 @@ export class QuillEditorComponent implements AfterViewInit, ControlValueAccessor
 
     // update model if text changes
     this.quillEditor.on('text-change', (delta: any, oldDelta: any, source: any) => {
-      let html: any;
-      for (let i = 0; i < this.editorElem.children.length; i++) {
-        if (this.editorElem.children[i].className == 'ql-editor') {
-          html = this.editorElem.children[i].innerHTML;
-          break;
+      let html: any = null;
+      if ('children' in this.editorElem) {
+        for (let i = 0; i < this.editorElem.children.length; i++) {
+          if ('className' in this.editorElem.children[i] && this.editorElem.children[i].className.indexOf('ql-editor') !== -1 && 'innerHTML' in this.editorElem.children[i]) {
+            html = this.editorElem.children[i].innerHTML;
+            break;
+          }
         }
       }
 

--- a/quillEditor.component.ts
+++ b/quillEditor.component.ts
@@ -108,7 +108,14 @@ export class QuillEditorComponent implements AfterViewInit, ControlValueAccessor
 
     // update model if text changes
     this.quillEditor.on('text-change', (delta: any, oldDelta: any, source: any) => {
-      let html = this.editorElem.children[0].innerHTML;
+      let html: any;
+      for (let i = 0; i < this.editorElem.children.length; i++) {
+        if (this.editorElem.children[i].className == 'ql-editor') {
+          html = this.editorElem.children[i].innerHTML;
+          break;
+        }
+      }
+
       const text = this.quillEditor.getText();
 
       if (html === '<p><br></p>') html = null;


### PR DESCRIPTION
Using this angular module you can allow the Grammarly Extension using the following code:

```
onEditorCreated(quill) {
    quill.root.removeAttribute('data-gramm');
}
```

The problem is that the Grammarly Extension adds a Div node in the Editor, causing the text-change event to update the NgModel with the wrong HTML code.
With this fix the NgModel will be updated properly.